### PR TITLE
Fix bug for merged pull requests that are later updated

### DIFF
--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -37,6 +37,7 @@ private
   end
 
   def check_off_pull_request
+    check_for_pr_checklist(trello_card)
     pr_checklist.items.each do |item|
       if item.name == pr_url
         pr_checklist.update_item_state(item.id, "complete")

--- a/spec/features/pr_poster_spec.rb
+++ b/spec/features/pr_poster_spec.rb
@@ -30,4 +30,12 @@ describe 'Pull Request Poster' do
     updated_checklist = trello_card.checklists.first
     expect(updated_checklist.check_items.first['state']).to eq('complete')
   end
+
+  it 'checks a Pull Request checkbox if the PR has been updated with a Trello URL after it was merged' do
+    github_pull_request = GitHubPullRequest.new(60356290, 3, true, trello_poster)
+    merged_pull_request = github_pull_request.login_user.pull_request(60356290, 1)
+    trello_card = github_pull_request.trello_poster.client.find(:card, 'Bjdv5qRr')
+    checklist = trello_card.checklists.first
+    expect(checklist.check_items.first['state']).to eq('complete')
+  end
 end


### PR DESCRIPTION
- This fixes a bug that occurs when someone updates a pull request message with a Trello card URL after the pull request was merged. This bug meant that, while the pull request URL was successfully posted to the checklist, it was not subsequently checked off. The reason for this is that the @pr_checklist variable contains the required checklist in its old state, so the app is looking for a pull request URL in an out-of-date checklist.  Now, before checking off the URL from the checklist, the app retrieves the latest version of the checklist.