### PR TITLE
Add index route and view

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,6 @@ Note the feature tests require real-world set up of Trello cards and GitHub repo
 **23/09/16**
 - Sinatra logging as been added.
 - Added test for HTTP request.
+
+**20/10/16**
+- Added index page with directions to the app's GitHub repo.

--- a/app.rb
+++ b/app.rb
@@ -10,7 +10,12 @@ class GithubTrelloPoster < Sinatra::Base
   configure :production, :development do
     enable :logging
   end
-  
+
+  get '/' do
+    status 200
+    erb :index
+  end
+
   post '/payload' do
     status 204
     body ''

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,0 +1,5 @@
+<h1>GitHub Trello Poster</h1>
+
+<p>This app uses GitHub webhooks to be notified when a Pull Request is opened or changed on GitHub. When it finds a link to a Trello card in the Pull Request, it posts a link to that Pull Request to a checklist on the given card. When a Pull Request is merged, the app checks the Pull Request off the checklist.</p>
+
+<p>For more information visit the app's <a href="https://github.com/emmabeynon/github-trello-posters">GitHub repo</a></p>


### PR DESCRIPTION
In order to provide information about the app to someone navigating to its index, I have added an index route and a view which gives a brief description of the app and a link to the app's GitHub repo.