### PR TITLE
Improve readability of GithubPullRequest

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,12 @@ class GithubTrelloPoster < Sinatra::Base
     body ''
     trello_poster = TrelloPoster.new(ENV['TRELLO_PUBLIC_KEY'], ENV['TRELLO_MEMBER_TOKEN'])
     payload = JSON.parse(request.body.read)
-    GitHubPullRequest.new(payload["repository"]["id"],payload["number"],payload["pull_request"]["merged"], trello_poster)
+
+    GitHubPullRequest.new(
+      repo: payload["repository"]["id"],
+      pull_request_id: payload["number"],
+      merged: payload["pull_request"]["merged"],
+      trello_poster: trello_poster)
   end
 
   # start the server if ruby file executed directly

--- a/lib/github_pull_request.rb
+++ b/lib/github_pull_request.rb
@@ -4,7 +4,7 @@ require 'octokit'
 class GitHubPullRequest
   attr_reader :login_user, :merged, :trello_poster
 
-  def initialize(repo, pull_request_id, merged, trello_poster)
+  def initialize(repo:, pull_request_id:, merged:, trello_poster:)
     @login_user = authenticate
     @merged = merged
     @trello_poster = trello_poster
@@ -21,7 +21,7 @@ class GitHubPullRequest
 private
 
   def authenticate
-    @login_user = Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
+    @authenticate ||= Octokit::Client.new(access_token: ENV['GITHUB_ACCESS_TOKEN'])
   end
 
   def check_for_trello_card(pr_url, pr_body)

--- a/spec/features/pr_poster_spec.rb
+++ b/spec/features/pr_poster_spec.rb
@@ -3,7 +3,25 @@ require 'github_pull_request'
 describe 'Pull Request Poster' do
   WebMock.allow_net_connect!
   let(:trello_poster) { TrelloPoster.new(ENV['TRELLO_PUBLIC_KEY'], ENV['TRELLO_MEMBER_TOKEN']) }
-  subject(:github_pr) { GitHubPullRequest.new(60356369, 1, false, trello_poster) }
+
+  subject(:github_pr) do
+    GitHubPullRequest.new(
+      repo: 60356369,
+      pull_request_id: 1,
+      merged: false,
+      trello_poster: trello_poster
+    )
+  end
+
+  let(:github_pull_request_params) do
+    {
+      repo: 60356369,
+      pull_request_id: 1,
+      merged: false,
+      trello_poster: trello_poster
+    }
+  end
+
   let(:pull_request) { github_pr.login_user.pull_request(60356369, 1) }
   let(:trello_card_id) { pull_request.body.match(/https:\/\/trello.com\/c\/\w{8}/)[0].gsub(/https:\/\/trello.com\/c\//, '') }
   let(:trello_card) { github_pr.trello_poster.client.find(:card, trello_card_id) }
@@ -24,21 +42,21 @@ describe 'Pull Request Poster' do
 
   context "when a pull request URL is already in a card's checklist" do
     it 'does not post a pull request URL to the Trello card' do
-      GitHubPullRequest.new(60356369, 1, false, trello_poster)
+      GitHubPullRequest.new(github_pull_request_params)
       expect(@checklist.check_items.count).to eq(1)
     end
   end
 
   context "when a pull request has been merged" do
     it "checks the Pull Request off the checklist" do
-      GitHubPullRequest.new(60356369, 1, true, trello_poster)
+      GitHubPullRequest.new(github_pull_request_params.merge(merged: true))
       updated_checklist = trello_card.checklists.first
       expect(updated_checklist.check_items.first['state']).to eq('complete')
     end
   end
 
   it 'checks a Pull Request checkbox if the PR has been updated with a Trello URL after it was merged' do
-    github_pull_request = GitHubPullRequest.new(60356290, 3, true, trello_poster)
+    github_pull_request = GitHubPullRequest.new(github_pull_request_params.merge(repo: 60356290))
     merged_pull_request = github_pull_request.login_user.pull_request(60356290, 1)
     trello_card = github_pull_request.trello_poster.client.find(:card, 'Bjdv5qRr')
     checklist = trello_card.checklists.first

--- a/spec/github_pull_request_spec.rb
+++ b/spec/github_pull_request_spec.rb
@@ -2,6 +2,15 @@ require 'github_pull_request'
 require 'ostruct'
 
 describe GitHubPullRequest do
+  let(:github_pull_request_params) do
+    {
+      repo: 60356369,
+      pull_request_id: 1,
+      merged: false,
+      trello_poster: trello_poster
+    }
+  end
+
   let(:trello_poster) { double(TrelloPoster) }
   let(:repo_pull_request) do
     OpenStruct.new({
@@ -10,7 +19,7 @@ describe GitHubPullRequest do
     })
   end
   let(:octokit) { double Octokit::Client, login: 'username', pull_request: repo_pull_request }
-  subject(:github_pr) { GitHubPullRequest.new(60356369, 1, false, trello_poster) }
+  subject(:github_pr) { GitHubPullRequest.new(github_pull_request_params) }
 
   before(:each) do
     allow(Octokit::Client).to receive(:new).and_return(octokit)
@@ -30,7 +39,7 @@ describe GitHubPullRequest do
   describe '#fetch_pull_request_data' do
     it 'retrieves HTML URL and body data for the given URL and passes to the check_for_trello_card method, leading to GitHubPullRequest being instantiated' do
       expect(trello_poster).to receive(:post!).with(repo_pull_request[:html_url], '6wQLN2C7', false)
-      GitHubPullRequest.new(60356369, 1, false, trello_poster)
+      GitHubPullRequest.new(github_pull_request_params)
     end
   end
 end


### PR DESCRIPTION
I've made three changes here

1.  allow the next person to understand what are those values
passed to GithubPullRequest.
2. make the tests of GithubPullRequest a bit more usable and less repetitive
3. memoize `authenticate` so you don't have to request `Octokit::Client` all the time.

Also note that all the tests under `spec/features/pr_poster_spec.rb` are red, this is because you didn't mock `Trello::Client` and made it return the necessary values for your tests to pass. 