### PR TITLE
Handle invalid GitHub payloads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :test do
   gem 'rspec'
   gem 'rspec-sinatra'
   gem 'webmock'
+  gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -94,6 +96,7 @@ DEPENDENCIES
   dotenv
   octokit (~> 4.0)
   puma
+  rack-test
   rspec
   rspec-sinatra
   ruby-trello (~> 1.5.1)

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+RSpec.describe GithubTrelloPoster do
+  include Rack::Test::Methods
+
+  def app
+    GithubTrelloPoster.new
+  end
+
+  describe "GET '/'" do
+    it "returns 200 response" do
+      response = get '/'
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "POST payload" do
+    let(:trello_poster) { TrelloPoster }
+    context "valid GitHub pull request payload is received" do
+      let(:payload) do
+        {
+          "pull_request": {
+            "merged": true
+          },
+          "number": 1,
+          "repository": {
+            "id": 1234
+          }
+        }
+      end
+
+      it "successfully instantiates GitHubPullRequest" do
+        expect(GitHubPullRequest).to receive(:new).with(
+          merged: true,
+          pull_request_id: 1,
+          repo_id: 1234,
+          trello_poster: trello_poster
+        )
+        post '/payload', payload.to_json,
+          { 'CONTENT_TYPE' => 'application/json'}
+      end
+
+      it "returns a 200 status" do
+        response = post '/payload', payload.to_json,
+          { 'CONTENT_TYPE' => 'application/json'}
+        expect(response.status).to eq(200)
+        expect(response.body).to be_empty
+      end
+    end
+
+    context "invalid GitHub pull request payload is received" do
+      let(:payload) { { "stuff": "things" } }
+
+      it "does not successfully instantiate GitHubPullRequest" do
+        expect(GitHubPullRequest).not_to receive(:new)
+        post '/payload', payload.to_json,
+          { 'CONTENT_TYPE' => 'application/json'}
+      end
+
+      it "returns a 400 error" do
+        response = post '/payload', payload.to_json,
+          { 'CONTENT_TYPE' => 'application/json'}
+        expect(response.status).to eq(400)
+        expect(response.body).to eq("Required payload fields missing")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'octokit'
 require 'byebug'
 require 'net/http'
 require 'net/https'
-
+require 'rack/test'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 


### PR DESCRIPTION
Previously the app would return a 500 error if an invalid payload is sent to
`/payload`.  Now we check if the payload contains the required attributes and
return a 400 response with a message indicating that the problem lies with the
payload if an incorrect payload is sent.