### PR TITLE
Refactor TrelloPoster

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,7 +23,7 @@ class GithubTrelloPoster < Sinatra::Base
     else
       return [400, 'Required payload fields missing']
     end
-    trello_poster = TrelloPoster.new(ENV['TRELLO_PUBLIC_KEY'], ENV['TRELLO_MEMBER_TOKEN'])
+    trello_poster = TrelloPoster.new
     GitHubPullRequest.new(
       merged: payload["pull_request"]["merged"],
       pull_request_id: payload["number"],

--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -1,56 +1,65 @@
 require 'trello'
+require 'byebug'
 
 class TrelloPoster
-  attr_reader :merge_status, :pr_checklist, :pr_url, :trello_card, :trello_card_id, :client
-
-  def initialize(public_key, token)
-    @client = Trello::Client.new( :developer_public_key => public_key, :member_token => token)
+  def initialize
+    @client = Trello::Client.new(
+      :developer_public_key => ENV['TRELLO_PUBLIC_KEY'],
+      :member_token => ENV['TRELLO_MEMBER_TOKEN']
+    )
   end
 
   def post!(pr_url, trello_card_id, merge_status)
-    @pr_checklist = nil
-    @pr_url = pr_url
-    @trello_card_id = trello_card_id
-    access_trello_card
-    post_github_pr_url
-    check_off_pull_request if merge_status
-  end
-
-  def access_trello_card
-    @trello_card = @client.find(:card, trello_card_id)
-    check_for_pr_checklist(trello_card)
-  end
-
-  def check_for_pr_checklist(trello_card)
-    trello_card.checklists.detect do |checklist|
-      @pr_checklist = checklist if is_a_pr_checklist?(checklist)
-    end
-    create_pr_checklist if pr_checklist.nil?
+    trello_card = access_trello_card(trello_card_id)
+    pr_checklist = check_for_pr_checklist(trello_card)
+    post_github_pr_url(pr_url, pr_checklist)
+    check_off_pull_request(trello_card, pr_url) if merge_status
   end
 
 private
 
-  def post_github_pr_url
-    unless pr_checklist.check_items.detect { |item| item["name"] == pr_url }
+  attr_reader :client
+
+  def access_trello_card(trello_card_id)
+    client.find(:card, trello_card_id)
+  end
+
+  def check_for_pr_checklist(trello_card)
+    checklist = trello_card.checklists.detect do |checklist|
+      return checklist if is_a_pr_checklist?(checklist)
+    end
+    create_pr_checklist(trello_card) if checklist.nil?
+  end
+
+  def post_github_pr_url(pr_url, pr_checklist)
+    unless checklist_has_pr_url?(pr_checklist, pr_url)
       pr_checklist.add_item(pr_url, checked=false, position='bottom')
     end
   end
 
-  def check_off_pull_request
-    check_for_pr_checklist(trello_card)
-    pr_checklist.items.each do |item|
-      if item.name == pr_url
-        pr_checklist.update_item_state(item.id, "complete")
-        pr_checklist.save
+  def check_off_pull_request(trello_card, pr_url)
+    checklist = check_for_pr_checklist(trello_card)
+    checklist.check_items.each do |item|
+      if item["name"] == pr_url
+        checklist.update_item_state(item["id"], "complete")
+        checklist.save
       end
     end
   end
 
-  def create_pr_checklist
-    @pr_checklist = client.create(:checklist, "name" => "Pull Requests", "idCard" => trello_card.id)
+  def create_pr_checklist(trello_card)
+    client.create(:checklist,
+      "name" => "Pull Requests",
+      "idCard" => trello_card.id
+    )
   end
 
   def is_a_pr_checklist?(checklist)
-    checklist.name.downcase == "pull requests" || checklist.name.downcase == "prs"
+    checklist.name.downcase == "pull requests" ||
+      checklist.name.downcase == "prs"
+  end
+
+  def checklist_has_pr_url?(checklist, pr_url)
+    checklist.check_items.detect { |item| item["name"] == pr_url }
   end
 end

--- a/spec/trello_poster_spec.rb
+++ b/spec/trello_poster_spec.rb
@@ -1,60 +1,136 @@
 require 'trello_poster'
 
 describe TrelloPoster do
-  subject(:trello_poster) { TrelloPoster.new(ENV['TRELLO_PUBLIC_KEY'], ENV['TRELLO_MEMBER_TOKEN']) }
-
-  let(:checklist_1) do
-    instance_double("Trello::Checklist", {:id=>"575987341d668cc732820859", :name=>"A checklist", :check_items=>[{"state"=>"incomplete", "id"=>"57598739c17fbe2dd6d794c0", "name"=>"An item"}], :card_id=>"57519cea330ce213a8b53a20"})
+  subject(:trello_poster) { TrelloPoster.new }
+  let(:trello_client) do
+    double Trello::Client,
+      find: trello_card_no_checklist,
+      create: pull_request_checklist
   end
 
-  let(:checklist_2) do
-    instance_double("Trello::Checklist", {:id=>"57598ceaa5ec5c2a9ac73e8f", :name=>"Pull Requests", :check_items=>[{"state"=>"incomplete", "id"=>"57598d26260429f99a03588d", "name"=>"https://github.com/gov-test-org/project-a/pull/1"}],
-    :card_id=>"57519cea330ce213a8b53a20"})
+  let(:another_checklist) do
+    instance_double("Trello::Checklist",
+      { :id=>"1",
+        :name=>"A checklist",
+        :check_items=>[
+          { "state"=>"incomplete",
+            "id"=>"1",
+            "name"=>"An item"
+          }
+        ],
+        :card_id=>"1",
+      }
+    )
   end
 
-  let(:card_checklists) { [checklist_1, checklist_2] }
+  let(:pull_request_checklist) do
+    instance_double("Trello::Checklist",
+      { :id=>"2",
+        :name=>"Pull Requests",
+        :check_items=>[
+          { "state"=>"incomplete",
+            "id"=>"1",
+            "name"=>"https://github.com/gov-test-org/project-a/pull/1"
+          }
+        ],
+        :card_id=>"1",
+      }
+    )
+  end
 
-  let(:trello_card) { instance_double("Trello::Card", :checklists => card_checklists, id: '') }
+  let(:card_checklists) { [another_checklist, pull_request_checklist] }
 
-  let(:trello_card_no_checklist) { instance_double("Trello::Card", :checklists => [], id: '5751a0d8b5534a7d47d93d12') }
+  let(:trello_card) do
+    instance_double("Trello::Card",
+      checklists: card_checklists,
+      id: 'abcd1234'
+    )
+  end
 
-  describe 'When a Trello card contains a "Pull Requests" checklist' do
+  let(:trello_card_no_checklist) do
+    instance_double("Trello::Card",
+      checklists: [],
+      id: 'efgh5678'
+    )
+  end
+
+  before do
+    allow(Trello::Client).to receive(:new).and_return(trello_client)
+  end
+
+  context "When a Trello card contains a 'Pull Requests' checklist" do
     before(:each) do
-      allow(trello_poster.client).to receive(:find).and_return(trello_card)
-      allow(trello_poster.client).to receive(:create).and_return(checklist_2)
-      allow(checklist_2).to receive(:add_item).with('https://github.com/gov-test-org/project-a/pull/2', false, "bottom")
-      trello_poster.post!('https://github.com/gov-test-org/project-a/pull/2', 'abcd1234', false)
+      allow(trello_client).to receive(:find).and_return(trello_card)
+      allow(pull_request_checklist).to receive(:add_item)
+        .with("https://github.com/gov-test-org/project-a/pull/2", false, "bottom")
     end
 
-    describe '#access_trello_card' do
-      it 'accesses a Trello card using a specific card id' do
-        expect(trello_poster.trello_card).to eq(trello_card)
+    context "and trello_card_id is valid" do
+      it "should find the Trello card via the Trello API" do
+        expect(trello_client).to receive(:find).and_return(trello_card)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/2', "abcd1234", false
+        )
+      end
+
+      it "should post the GitHub PR URL to the 'Pull Requests' checklist" do
+        expect(pull_request_checklist).to receive(:add_item)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/2', "abcd1234", false
+        )
+      end
+
+      it "should not post the GitHub PR URL to checklist that is not called 'Pull Requests'" do
+        expect(another_checklist).not_to receive(:add_item)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/2', "abcd1234", false
+        )
       end
     end
 
-    describe '#check_for_pr_checklist' do
-      it 'checks for the presence of a PR checklist in a specified Trello card and stores in the pr_checklist variable' do
-        expect(trello_poster.pr_checklist).to eq(checklist_2)
+    context "and merge status is true" do
+      before do
+        allow(pull_request_checklist).to receive(:update_item_state)
+        allow(pull_request_checklist).to receive(:save)
       end
 
-      it 'does not store a checklist in the pr_checklist variable if it is not called "Pull Requests" or "PRs"' do
-        expect(trello_poster.pr_checklist).not_to eq(checklist_1)
+      it "should check off the pull request on the checklist" do
+        expect(pull_request_checklist).to receive(:update_item_state)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/1', "abcd1234", true
+        )
+      end
+    end
+
+    context "and merge status is false" do
+      it "should not check off the pull request on the checklist" do
+        expect(pull_request_checklist).not_to receive(:update_item_state)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/2', "abcd1234", false
+        )
       end
     end
   end
 
-  describe 'When a Trello card does not contain a "Pull Requests" checklist' do
+  context "When a Trello card does not contain a 'Pull Requests' checklist" do
     before(:each) do
-      allow(trello_poster.client).to receive(:find).and_return(trello_card_no_checklist)
-      allow(trello_poster.client).to receive(:create).and_return(checklist_2)
-      allow(checklist_2).to receive(:add_item).with('https://github.com/gov-test-org/project-a/pull/2', false, "bottom")
-      trello_poster.post!('https://github.com/gov-test-org/project-a/pull/2', 'abcd1234', false)
+      allow(trello_client)
+        .to receive(:find).and_return(trello_card_no_checklist)
+      allow(pull_request_checklist).to receive(:add_item)
+        .with("https://github.com/gov-test-org/project-a/pull/2", false, "bottom")
     end
 
-    describe '#check_for_pr_checklist' do
-      it 'creates a checklist called "Pull Requests" if it does not already exist' do
-        expect(trello_poster.pr_checklist).to eq(checklist_2)
-      end
+    it "should create a checklist via the Trello API" do
+      expect(trello_client).to receive(:create).and_return(pull_request_checklist)
+
+      trello_poster.post!(
+        "https://github.com/gov-test-org/project-a/pull/2", "efgh5678", false
+      )
     end
   end
 end


### PR DESCRIPTION
* Reduce number of instance variables, as there's no need for them to be accessed directly on the instance
* Move more methods to private as they don't need to be accessed independently
* Extract code to check if a checklist has a PR URL to its own method, `checklist_has_pr_url?` so it's clearer what this code does
* In `check_off_pull_request` iterate through `check_items` instead of `items` on checklist as the data structure is simpler and is consistents with `checklist_has_pr_url?`