### PR TITLE
Don't post a GitHub PR URL to a checklist more than once

### DIFF
--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -1,5 +1,4 @@
 require 'trello'
-require 'byebug'
 
 class TrelloPoster
   def initialize
@@ -32,18 +31,16 @@ private
   end
 
   def post_github_pr_url(pr_url, pr_checklist)
-    unless checklist_has_pr_url?(pr_checklist, pr_url)
-      pr_checklist.add_item(pr_url, checked=false, position='bottom')
-    end
+    item = pr_url_on_checklist(pr_checklist, pr_url)
+    pr_checklist.add_item(pr_url, checked=false, position='bottom') if item.nil?
   end
 
   def check_off_pull_request(trello_card, pr_url)
     checklist = check_for_pr_checklist(trello_card)
-    checklist.check_items.each do |item|
-      if item["name"] == pr_url
-        checklist.update_item_state(item["id"], "complete")
-        checklist.save
-      end
+    item = pr_url_on_checklist(checklist, pr_url)
+    unless item.nil?
+      checklist.update_item_state(item["id"], "complete")
+      checklist.save
     end
   end
 
@@ -59,7 +56,7 @@ private
       checklist.name.downcase == "prs"
   end
 
-  def checklist_has_pr_url?(checklist, pr_url)
-    checklist.check_items.detect { |item| item["name"] == pr_url }
+  def pr_url_on_checklist(checklist, pr_url)
+    checklist.check_items.find { |item| item["name"] =~ /#{Regexp.quote(pr_url)}/i }
   end
 end

--- a/spec/trello_poster_spec.rb
+++ b/spec/trello_poster_spec.rb
@@ -30,7 +30,7 @@ describe TrelloPoster do
         :check_items=>[
           { "state"=>"incomplete",
             "id"=>"1",
-            "name"=>"https://github.com/gov-test-org/project-a/pull/1"
+            "name"=>"https://github.com/gov-test-org/project-a/pull/1 - Add the UI to frontend"
           }
         ],
         :card_id=>"1",
@@ -87,6 +87,14 @@ describe TrelloPoster do
 
         trello_poster.post!(
           'https://github.com/gov-test-org/project-a/pull/2', "abcd1234", false
+        )
+      end
+
+      it "should not post the GitHub PR URL more than once" do
+        expect(pull_request_checklist).not_to receive(:add_item)
+
+        trello_poster.post!(
+          'https://github.com/gov-test-org/project-a/pull/1', "abcd1234", false
         )
       end
     end


### PR DESCRIPTION
As per [this feature request](https://github.com/emmabeynon/github-trello-poster/issues/41) there are occasions where after a PR URL has been posted to a checklist, a user of the Trello card may annotate it. In these cases, GitHubTrelloPoster would not recognise the URL and would post a duplicate. We now use a regex to check if the PR URL is present on a checklist item, thereby avoiding instances of the PR being posted more than once.