### PR TITLE
Check off PR URL items on checklist if PR is closed

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,7 +25,7 @@ class GithubTrelloPoster < Sinatra::Base
     end
     trello_poster = TrelloPoster.new
     GitHubPullRequest.new(
-      merged: payload["pull_request"]["merged"],
+      closed: payload["action"] == "closed",
       pull_request_id: payload["number"],
       repo_id: payload["repository"]["id"],
       trello_poster: trello_poster
@@ -34,7 +34,7 @@ class GithubTrelloPoster < Sinatra::Base
 
   def required_payload_fields(payload)
     return false if payload.nil?
-    !payload.dig("pull_request", "merged").nil? &&
+    payload["action"].present? &&
     payload["number"].present? &&
     payload.dig("repository", "id").present?
   end

--- a/lib/github_pull_request.rb
+++ b/lib/github_pull_request.rb
@@ -4,9 +4,9 @@ require 'octokit'
 class GitHubPullRequest
   attr_reader :pull_request_id, :repo_id
 
-  def initialize(merged: false, pull_request_id:, repo_id:, trello_poster:)
+  def initialize(closed:, pull_request_id:, repo_id:, trello_poster:)
     @login_user = authenticate
-    @merged = merged
+    @closed = closed
     @pull_request_id = pull_request_id
     @repo_id = repo_id
     @trello_poster = trello_poster
@@ -21,7 +21,7 @@ class GitHubPullRequest
 
 private
 
-  attr_reader :login_user, :merged, :trello_poster
+  attr_reader :login_user, :closed, :trello_poster
 
   def fetch_pull_request_data(repo_id, pull_request_id)
     login_user.pull_request(repo_id, pull_request_id)
@@ -43,6 +43,6 @@ private
   end
 
   def post_to_trello(pr_url, trello_card_id)
-    trello_poster.post!(pr_url, trello_card_id, merged)
+    trello_poster.post!(pr_url, trello_card_id, closed)
   end
 end

--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -1,5 +1,4 @@
 require 'trello'
-require 'byebug'
 
 class TrelloPoster
   def initialize
@@ -9,11 +8,11 @@ class TrelloPoster
     )
   end
 
-  def post!(pr_url, trello_card_id, merge_status)
+  def post!(pr_url, trello_card_id, pr_closed)
     trello_card = access_trello_card(trello_card_id)
     pr_checklist = check_for_pr_checklist(trello_card)
     post_github_pr_url(pr_url, pr_checklist)
-    check_off_pull_request(trello_card, pr_url) if merge_status
+    check_off_pull_request(trello_card, pr_url) if pr_closed
   end
 
 private

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GithubTrelloPoster do
     let(:trello_poster) { TrelloPoster }
     let(:github_pull_request_params) do
       {
-        merged: true,
+        closed: false,
         pull_request_id: 1,
         repo_id: 1234,
         trello_poster: trello_poster
@@ -36,9 +36,7 @@ RSpec.describe GithubTrelloPoster do
     context "valid GitHub pull request payload is received" do
       let(:payload) do
         {
-          "pull_request": {
-            "merged": true
-          },
+          "action": "open",
           "number": 1,
           "repository": {
             "id": 1234

--- a/spec/github_pull_request_spec.rb
+++ b/spec/github_pull_request_spec.rb
@@ -21,7 +21,7 @@ describe GitHubPullRequest do
     {
       repo_id: 60356369,
       pull_request_id: 1,
-      merged: false,
+      closed: false,
       trello_poster: trello_poster
     }
   end

--- a/spec/trello_poster_spec.rb
+++ b/spec/trello_poster_spec.rb
@@ -91,7 +91,7 @@ describe TrelloPoster do
       end
     end
 
-    context "and merge status is true" do
+    context "and pr_closed is true" do
       before do
         allow(pull_request_checklist).to receive(:update_item_state)
         allow(pull_request_checklist).to receive(:save)
@@ -106,7 +106,7 @@ describe TrelloPoster do
       end
     end
 
-    context "and merge status is false" do
+    context "and pr_closed is false" do
       it "should not check off the pull request on the checklist" do
         expect(pull_request_checklist).not_to receive(:update_item_state)
 


### PR DESCRIPTION
As per [this
issue](https://github.com/emmabeynon/github-trello-poster/issues/37) when a PR
is closed but not merged `GitHubTrelloPoster` does not tick this off the
checklist.  After investigation I found that when a PR is either closed or
merged GitHub sets "action" in the payload to "closed". We change app.rb to
check if the "action" is "closed" or not and send this boolean as an argument
to `GitHubPullRequest` upon initialization instead of "merged".