### PR TITLE
Fix duplicate posts when review requested

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -18,6 +18,7 @@ class GithubTrelloPoster < Sinatra::Base
 
   post '/payload' do
     payload = JSON.parse(request.body.read)
+    return [200, 'Not processing payload'] if review_requested?(payload)
     if required_payload_fields(payload).present?
       [200, '']
     else
@@ -42,4 +43,7 @@ class GithubTrelloPoster < Sinatra::Base
   # start the server if ruby file executed directly
   run! if app_file == $0
 
+  def review_requested?(payload)
+    payload["action"] == "review_requested"
+  end
 end


### PR DESCRIPTION
When reviews are requested it seems that GitHub sends two payloads - one with
action "opened", one with action "review_requested" - in the same second. This
app doesn't process payloads quickly enough, meaning that there are cases where
two pull request checklists or two of the same PR links are posted. This
overcomes this by checking if the payload has action "review_requested" before
processing it.