### PR TITLE
Add distribution to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 before_install:
 - gem update --system
 script:


### PR DESCRIPTION
Travis has migrated the build for this repo over to their Xenial image, which
is causing the build to fail. This sets the distribution to Trusty to fix this.