### PR TITLE
Upgrade Bundler to v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,4 +112,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
We have started getting `Could not find 'bundler' (1.17.2)` in our Travis
builds.  Instead of specifying that Travis install an older version of bundler,
we might as well upgrade to the latest version.